### PR TITLE
Fix db server migration

### DIFF
--- a/devmaster.make
+++ b/devmaster.make
@@ -40,8 +40,8 @@ projects[jquery_update][subdir] = contrib
 projects[views][version] = "3.2"
 projects[views][subdir] = contrib
 
-projects[views_bulk_operations][version] = "1.16"
-projects[views_bulk_operations][subdir] = contrib
+;projects[views_bulk_operations][version] = "1.16"
+;projects[views_bulk_operations][subdir] = contrib
 
 projects[ctools][version] = "1.12"
 projects[ctools][subdir] = contrib

--- a/devmaster.make
+++ b/devmaster.make
@@ -12,6 +12,7 @@ includes[devshop] = "drupal-org.make"
 ; For development, use latest branch.
 ; NOTE: We are using 2.x of hosting until the next release.
 projects[hosting][version] = "2.x"
+projects[hosting][patch][] = "patches/hosting.patch"
 
 ; For release, use tagged version
 ;projects[hosting][version] = "2.4"

--- a/modules/devshop/devshop_projects/inc/forms.inc
+++ b/modules/devshop/devshop_projects/inc/forms.inc
@@ -103,14 +103,7 @@ function devshop_projects_form_alter(&$form, &$form_state, $form_id){
 
           foreach ($form['parameters'] as $key => &$element) {
             if (is_int($key)) {
-              // Don't unset the target platform. Just hide it.
-              if (isset($element['target_platform']['#default_value'])) {
-                $form['parameters'][$key]['target_platform']['#type'] = 'value';
-                $form['parameters'][$key]['target_platform']['#value'] = $form['parameters'][$key]['target_platform']['#default_value'];
-              }
-              else {
-                unset($form['parameters'][$key]);
-              }
+              unset($form['parameters'][$key]);
             }
           }
           $form['parameters']['#suffix'] = '</div>';

--- a/modules/devshop/devshop_projects/inc/forms.inc
+++ b/modules/devshop/devshop_projects/inc/forms.inc
@@ -103,7 +103,14 @@ function devshop_projects_form_alter(&$form, &$form_state, $form_id){
 
           foreach ($form['parameters'] as $key => &$element) {
             if (is_int($key)) {
-              unset($form['parameters'][$key]);
+              // Don't unset the target platform. Just hide it.
+              if (isset($element['target_platform']['#default_value'])) {
+                $form['parameters'][$key]['target_platform']['#type'] = 'value';
+                $form['parameters'][$key]['target_platform']['#value'] = $form['parameters'][$key]['target_platform']['#default_value'];
+              }
+              else {
+                unset($form['parameters'][$key]);
+              }
             }
           }
           $form['parameters']['#suffix'] = '</div>';

--- a/patches/hosting.patch
+++ b/patches/hosting.patch
@@ -1,0 +1,14 @@
+diff --git a/hosting.info b/hosting.info
+index b955b47..16ac253 100644
+--- a/hosting.info
++++ b/hosting.info
+@@ -4,7 +4,7 @@ package = Hosting
+ dependencies[] = modalframe
+ dependencies[] = jquery_update
+ dependencies[] = views
+-dependencies[] = views_bulk_operations
++#dependencies[] = views_bulk_operations
+ dependencies[] = ctools
+ #dependencies[] = hosting_task
+ #dependencies[] = hosting_client
+


### PR DESCRIPTION
This allows the target platform parameter to be passed which was causing tasks to fail when it was missing during a migration of the database to another server.
