### PR TITLE
Add Devinci Behat Context integration.

### DIFF
--- a/modules/devshop/devshop_testing/tests_example/behat.yml
+++ b/modules/devshop/devshop_testing/tests_example/behat.yml
@@ -6,8 +6,14 @@ default:
         - Drupal\DrupalExtension\Context\DrupalContext
         - Drupal\DrupalExtension\Context\MinkContext
         - Drupal\DrupalExtension\Context\MessageContext
+        
         - Drupal\DrupalExtension\Context\DrushContext
-  extensions:
+        # If you wish to capture screenshots and HTM assets, uncomment these lines.
+        # See https://github.com/DevinciHQ/devinci-behat-extension
+        # If you add this line, DevShop will set the asset_dump_path automatically.
+        #
+        # - Devinci\DevinciExtension\Context\DebugContext:
+        #      asset_dump_path: %paths.base%/../assets/
     Behat\MinkExtension:
       goutte: ~
       selenium2: ~


### PR DESCRIPTION
Devinci has the asset_dump_path behat yml config.

DevShop takes your behat.yml file and writes a new one every time it writes tests.

DevShop will write the path of asset_dump_path as the public files of the devmaster site. 

This way devshop web UI users will be able to see images and HTML (and it could be linked from github as well.)

I did this years ago as a test.  Time to add it in.