### PR TITLE
Fix for proper cloning of project's Git repo without the Drupal path …

### DIFF
--- a/modules/devshop/devshop_projects/drush/Provision/Service/project.php
+++ b/modules/devshop/devshop_projects/drush/Provision/Service/project.php
@@ -21,6 +21,7 @@ class Provision_Service_project extends Provision_Service {
   static function subscribe_platform($context) {
     $context->setProperty('environment');
     $context->setProperty('project');
+    $context->setProperty('drupal_path');
   }
 
 }

--- a/modules/devshop/devshop_projects/drush/contexts.inc
+++ b/modules/devshop/devshop_projects/drush/contexts.inc
@@ -48,10 +48,10 @@ function devshop_projects_hosting_site_context_options(&$task) {
 }
 
 /**
- * Implements hook_hosting_site_context_options().
+ * Implements hook_hosting_platform_context_options().
  *
  * Runs on verify task. Passes data to the drush alias.
- * Save environment name, project name, and git ref to site aliases.
+ * Save environment name, project name, git ref, and drupal_path to site aliases.
  */
 function devshop_projects_hosting_platform_context_options(&$task) {
 
@@ -59,6 +59,7 @@ function devshop_projects_hosting_platform_context_options(&$task) {
     $task->context_options['environment'] = $task->ref->environment->name;
     $task->context_options['project'] = $task->ref->project->name;
     $task->context_options['git_ref'] = $task->ref->environment->git_ref;
+    $task->context_options['drupal_path'] = $task->ref->project->drupal_path;
   }
 }
 

--- a/modules/devshop/devshop_projects/drush/devshop_provision.drush.inc
+++ b/modules/devshop/devshop_projects/drush/devshop_provision.drush.inc
@@ -440,6 +440,18 @@ function drush_devshop_provision_pre_provision_verify() {
 }
 
 /**
+ * Implementatoin of drush_HOOK_pre_provision_git_clone()
+ *
+ * This will rewrite the git clone path to remove the drupal_path.
+ */
+function drush_devshop_provision_pre_provision_git_clone() {
+  if (d()->type === 'platform' && !empty(d()->drupal_path)) {
+    $drupal_path = '/' . d()->drupal_path;
+    d()->root = str_replace($drupal_path, '', d()->root);
+  }
+}
+
+/**
  * Implementation of drush_hook_post_provision_install()
  *
  * This function handles all of the alternative environment install methods.


### PR DESCRIPTION
When cloning a new project, Git tries to clone to the Drupal path. Resulting in a an error "We could not find an applicable site for that command. Drush could not bootstrap this platform. Please check the platform directory exists and is readable."

That is because the git clone command will use the platform path as a git clone path. This is wrong, it should clone to the environment path without the Drupal path.

This fixes it.	
