### PR TITLE
Add upgrade tests to devmaster's travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ branches:
   only:
     - 1.x
 
-env:
+#env:
 #  matrix:
 #  - test="Upgrade"
 #    distribution="ubuntu"
@@ -53,6 +53,18 @@ env:
 #    - dev.drpl8.devshop.travis
 #    - test.drpl8.devshop.travis
 
+env:
+  global:
+    - SITE_HOSTS='dev.drup.devshop.travis dev.projectname.devshop.travis live.projectname.devshop.travis testenv.drpl8.devshop.travis'
+
+  matrix:
+  - test="Upgrade"
+    UPGRADE_FROM_VERSION="1.0.0-beta10"
+    ROBO_UP_OPTIONS="--test-upgrade"
+
+  - test="Install"
+    ROBO_UP_OPTIONS="--test"
+
 services:
   - docker
 
@@ -84,7 +96,7 @@ before_install:
   - composer install -d tests
 
 script:
-  - robo up --test -n
+  - robo up ${ROBO_UP_OPTIONS} -n
 
 #  - container_id=$(mktemp)
 #    # Run container in detached state

--- a/modules/devshop/devshop_projects/devshop_projects.install
+++ b/modules/devshop/devshop_projects/devshop_projects.install
@@ -447,10 +447,3 @@ function devshop_projects_update_7008 () {
     ->execute();
 
 }
-
-/**
- * Intentionally broken update, for testing the testing!
- */
-function devshop_projects_update_7009 () {
-  not_a_function();
-}

--- a/modules/devshop/devshop_projects/devshop_projects.install
+++ b/modules/devshop/devshop_projects/devshop_projects.install
@@ -447,3 +447,10 @@ function devshop_projects_update_7008 () {
     ->execute();
 
 }
+
+/**
+ * Intentionally broken update, for testing the testing!
+ */
+function devshop_projects_update_7009 () {
+  not_a_function();
+}


### PR DESCRIPTION
Now that devshop repo's travis file tests, upgrade, it's time to get devmaster to do the same.