### PR TITLE
Project settings form fails on error.

### DIFF
--- a/modules/devshop/devshop_projects/inc/forms.inc
+++ b/modules/devshop/devshop_projects/inc/forms.inc
@@ -387,16 +387,6 @@ function devshop_projects_validate($node, &$form, &$form_state) {
   if (db_query('SELECT n.nid FROM {hosting_devshop_project} d LEFT JOIN {node} n ON d.nid = n.nid WHERE status = :status AND base_url = :base_url;', array(':status' => 1, ':base_url' => $form_state['values']['project']['base_url']))->fetchField()) {
     form_set_error('base_url', t('Another project already has this base url.  Base URL must be unique.'));
   }
-
-  // If custom code paths are not allowed, set the value here using the project name.
-  if (!variable_get('devshop_projects_allow_custom_code_path', FALSE)) {
-    form_set_value($form['code_path'], variable_get('devshop_project_base_path', '/var/aegir/projects') . '/' . $project_name, $form_state);
-  }
-
-  // If custom base URLs are not allowed, set the value here using the project name.
-  if (!variable_get('devshop_projects_allow_custom_base_url', FALSE)) {
-    form_set_value($form['base_url'], devshop_projects_url($project_name), $form_state);
-  }
 }
 
 /**

--- a/modules/devshop/devshop_projects/inc/forms.inc
+++ b/modules/devshop/devshop_projects/inc/forms.inc
@@ -387,6 +387,16 @@ function devshop_projects_validate($node, &$form, &$form_state) {
   if (db_query('SELECT n.nid FROM {hosting_devshop_project} d LEFT JOIN {node} n ON d.nid = n.nid WHERE status = :status AND base_url = :base_url;', array(':status' => 1, ':base_url' => $form_state['values']['project']['base_url']))->fetchField()) {
     form_set_error('base_url', t('Another project already has this base url.  Base URL must be unique.'));
   }
+
+  // If custom code paths are not allowed, set the value here using the project name.
+  if (!variable_get('devshop_projects_allow_custom_code_path', FALSE)) {
+    form_set_value($form['code_path'], variable_get('devshop_project_base_path', '/var/aegir/projects') . '/' . $project_name, $form_state);
+  }
+
+  // If custom base URLs are not allowed, set the value here using the project name.
+  if (!variable_get('devshop_projects_allow_custom_base_url', FALSE)) {
+    form_set_value($form['base_url'], devshop_projects_url($project_name), $form_state);
+  }
 }
 
 /**

--- a/tests/features/project.create.feature
+++ b/tests/features/project.create.feature
@@ -119,8 +119,7 @@ Feature: Create a project
     Then I move backward one page
     When I click "Project Settings"
     Then I select "testenv" from "Primary Environment"
+    And I press "save"
 
-  # @TODO: Remove on the next commit to trigger a test failure.
-#    And I press "save"
-#    Then I should see "DevShop Project drpl8 has been updated."
-#    And I should see an ".environment-link .fa-bolt" element
+    Then I should see "DevShop Project drpl8 has been updated."
+    And I should see an ".environment-link .fa-bolt" element

--- a/tests/features/project.create.feature
+++ b/tests/features/project.create.feature
@@ -115,3 +115,12 @@ Feature: Create a project
 
     When I click "Visit Site"
     Then I should see "Welcome to testenv.drpl8"
+
+    Then I move backward one page
+    When I click "Project Settings"
+    Then I select "testenv" from "Primary Environment"
+
+  # @TODO: Remove on the next commit to trigger a test failure.
+#    And I press "save"
+#    Then I should see "DevShop Project drpl8 has been updated."
+#    And I should see an ".environment-link .fa-bolt" element


### PR DESCRIPTION
Tracked it down to incorrect value setting on code path element. 

TDD time:
- [x] The first commit should pass, I only added steps to visit the settings page.
- [ ] The second commit should fail, this one has the steps to save the settings page and a check for a "successful project settings" saved message.
- [ ] The third commit fixes the bug.