### PR TITLE
Ensure "install_method" options are saved when site form is saved.

### DIFF
--- a/modules/devshop/devshop_projects/inc/forms.inc
+++ b/modules/devshop/devshop_projects/inc/forms.inc
@@ -63,7 +63,7 @@ function devshop_projects_form_project_node_form_alter(&$form, &$form_state, $fo
   $form['project']['codebase']['drupal_path'] = array(
     '#type' => 'textfield',
     '#title' => t('Path to Drupal'),
-    '#description' => t('Enter the relative path to the index.php file in your repository. Leave blank if index.php is in the root.'),
+    '#description' => t('Enter the relative path to the index.php file in your repository. Leave blank if index.php is in the root. If using a makefile, this is the path where Drupal will be built.'),
     '#size' => 40,
     '#default_value' => $project->drupal_path,
     '#maxlength' => 255,
@@ -71,6 +71,20 @@ function devshop_projects_form_project_node_form_alter(&$form, &$form_state, $fo
     '#parents' => array(
       'project',
       'drupal_path',
+    ),
+  );
+  $form['project']['codebase']['makefile_path'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Path to Makefile'),
+    '#description' => t('Enter the relative path to a makefile inside your repository. Leave blank if a full Drupal codebasee is in the repository.'),
+    '#size' => 40,
+    '#default_value' => $project->settings->makefile_path,
+    '#maxlength' => 255,
+    '#weight' => 4,
+    '#parents' => array(
+      'project',
+      'settings',
+      'makefile_path',
     ),
   );
   $form['project']['codebase']['base_url'] = array(
@@ -851,6 +865,14 @@ function devshop_projects_form_site_node_form_alter(&$form, &$form_state, $form_
     $form['hosting_https_wrapper']['#title'] = t('HTTPS');
     $form['hosting_https_wrapper']['#prefix'] = '';
     $form['hosting_https_wrapper']['#suffix'] = '';
+  }
+
+  // Ensure values are saved.
+  if (!isset($form['install_method'])) {
+    $form['install_method'] = array(
+      '#type' => 'value',
+      '#value' => $environment->settings->install_method,
+    );
   }
   
   // Add our own submit handler.


### PR DESCRIPTION
Our extra "install method" options were lost when environment settings were saved because we didn't include a placeholder in the form.