### PR TITLE
Always load $site_node->profile_name. Site's cloned from sites instal…

### DIFF
--- a/modules/devshop/devshop_projects/inc/nodes.inc
+++ b/modules/devshop/devshop_projects/inc/nodes.inc
@@ -125,9 +125,7 @@ function devshop_projects_node_load($nodes, $types) {
       if (isset($node->environment->settings->install_method)) {
         // Load install method into an easy to access property.
         $node->install_method = $node->environment->settings->install_method['method'];
-        if ($node->install_method == 'profile') {
-          $node->profile_name = $node->environment->settings->install_method['profile'];
-        }
+        $node->profile_name = $node->environment->settings->install_method['profile'];
       }
     }
   }


### PR DESCRIPTION
…led from custom profiles need this to be set properly, otherwise, it uses "standard" and won't find modules in `profiles/MYPROFILE/modules`.