### PR TITLE
Attempt to override development make yml instead of build-devmaster.make

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,10 +54,7 @@ before_install:
   - git checkout -qf ${DEVSHOP_VERSION}
   - git status
   - pwd
-  - 'echo "  devmaster:            " >> build-devmaster-dev.make.yml'
-  - 'echo "    download:           " >> build-devmaster-dev.make.yml'
-  - 'echo "      type: copy        " >> build-devmaster-dev.make.yml'
-  - 'echo "      url: ../devmaster " >> build-devmaster-dev.make.yml'
+  - cp build-devmaster-travis-forks.make.yml build-devmaster-dev.make.yml
   - cat build-devmaster-dev.make.yml
 
   # Prepare devshop CLI.

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,10 +54,10 @@ before_install:
   - git checkout -qf ${DEVSHOP_VERSION}
   - git status
   - pwd
-  - echo "  devmaster:     " >> build-devmaster-dev.make.yml
-  - echo "    download:    " >> build-devmaster-dev.make.yml
-  - echo "      type: copy " >> build-devmaster-dev.make.yml
-  - echo "      url: '../devmaster'" >> build-devmaster-dev.make.yml
+  - 'echo "  devmaster:            " >> build-devmaster-dev.make.yml'
+  - 'echo "    download:           " >> build-devmaster-dev.make.yml'
+  - 'echo "      type: copy        " >> build-devmaster-dev.make.yml'
+  - 'echo "      url: ../devmaster " >> build-devmaster-dev.make.yml'
   - cat build-devmaster-dev.make.yml
 
   # Prepare devshop CLI.

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,9 +54,11 @@ before_install:
   - git checkout -qf ${DEVSHOP_VERSION}
   - git status
   - pwd
-  - echo projects[devmaster][download][type] = "copy" >> build-devmaster.make
-  - echo projects[devmaster][download][url] = "../devmaster" >> build-devmaster.make
-  - cat build-devmaster.make
+  - echo "  devmaster:     " >> build-devmaster-dev.make.yml
+  - echo "    download:    " >> build-devmaster-dev.make.yml
+  - echo "      type: copy " >> build-devmaster-dev.make.yml
+  - echo "      url: '../devmaster'" >> build-devmaster-dev.make.yml
+  - cat build-devmaster-dev.make.yml
 
   # Prepare devshop CLI.
   - composer install


### PR DESCRIPTION
Now that we have a development make yml file (which is the default for `robo up`, so for all tests) We need a new formatting for our copy-over-makefile trick.