### PR TITLE
Fix ghost tasks appearing

### DIFF
--- a/modules/devshop/devshop_projects/inc/tasks-ajax.inc
+++ b/modules/devshop/devshop_projects/inc/tasks-ajax.inc
@@ -14,7 +14,9 @@ function devshop_projects_tasks_status_json() {
             last_task
         FROM {hosting_devshop_project_environment} e
         LEFT JOIN {node} n ON e.project_nid = n.nid
+        LEFT JOIN {hosting_site} s ON e.site = s.nid
           WHERE n.status = 1
+          AND s.site_status = 1
         ';
 
   $results = db_query($sql);

--- a/modules/devshop/devshop_projects/inc/tasks-ajax.inc
+++ b/modules/devshop/devshop_projects/inc/tasks-ajax.inc
@@ -16,7 +16,7 @@ function devshop_projects_tasks_status_json() {
         LEFT JOIN {node} n ON e.project_nid = n.nid
         LEFT JOIN {hosting_site} s ON e.site = s.nid
           WHERE n.status = 1
-          AND s.site_status = 1
+          AND s.site_status != -2
         ';
 
   $results = db_query($sql);


### PR DESCRIPTION
When an old environment is deleted, and a new one is created, sometimes the old environment's tasks appear (like the delete task).

This change makes sure to only load the tasks for sites that are not deleted.