### PR TITLE
Better Tasks display

### DIFF
--- a/modules/devshop/devshop_projects/devshop_projects.module
+++ b/modules/devshop/devshop_projects/devshop_projects.module
@@ -195,6 +195,7 @@ function devshop_environment_menu_first_items($environment, $tasks) {
     $url = url($href, array(
       'query' => array(
         'token' => drupal_get_token($user->uid),
+        'redirect' => 'task-page',
       )
     ));
     $title = $tasks['test']['title'];

--- a/modules/devshop/devshop_projects/inc/nodes.inc
+++ b/modules/devshop/devshop_projects/inc/nodes.inc
@@ -158,7 +158,10 @@ function devshop_projects_node_insert($node) {
     }
 
     // When a task is created or updated that has a project, redirect to the project.
-    if (isset($site->project) && arg(0) == 'hosting_confirm' && arg(1) == $site->nid) {
+    if (isset($_GET['redirect']) && $_GET['redirect'] == 'task-page') {
+      drupal_goto("node/{$node->nid}");
+    }
+    elseif (isset($site->project) && arg(0) == 'hosting_confirm' && arg(1) == $site->nid) {
       drupal_goto("node/{$site->project->nid}");
     }
   }

--- a/modules/devshop/devshop_projects/inc/task-ajax.js
+++ b/modules/devshop/devshop_projects/inc/task-ajax.js
@@ -190,5 +190,51 @@
               }
           });
       }
+  };
+
+  Drupal.behaviors.taskInfoScroll = {
+    attach: function (context, settings) {
+
+        var $task_info = $("#task-info");
+        if ($task_info.length == 0) {
+            return;
+        }
+        var task_info_top = $task_info.offset().top;
+        var $project_links = $("#project-environment-links");
+        var project_links_top = $project_links.offset().top;
+
+        // Check on first load.
+        if (window.pageYOffset >= task_info_top){
+            $task_info.addClass("task-info-fixed");
+        }
+        if (window.pageYOffset >= project_links_top){
+            $project_links.addClass("project-environment-links-fixed");
+        }
+
+        // On scroll, check.
+        window.onscroll = function() {
+            if (Drupal.settings.disableScrollCheck) {
+                return;
+            }
+
+            if (window.pageYOffset == 0) {
+                $task_info.removeClass("task-info-fixed");
+            }
+
+            if (window.pageYOffset >= task_info_top + 50){
+                $task_info.addClass("task-info-fixed");
+            }
+            else if ($('#follow').length && !$('#follow').prop('checked')) {
+                $task_info.removeClass("task-info-fixed");
+            }
+
+            if (window.pageYOffset >= project_links_top){
+                $project_links.addClass("project-environment-links-fixed");
+            }
+            else if (!$('#follow').prop('checked')) {
+                $project_links.removeClass("project-environment-links-fixed");
+            }
+        }
+    }
   }
 }(jQuery));

--- a/modules/devshop/devshop_projects/inc/theme.inc
+++ b/modules/devshop/devshop_projects/inc/theme.inc
@@ -206,7 +206,7 @@ function devshop_projects_preprocess_node(&$vars) {
     if ($vars['node']->task_status == HOSTING_TASK_PROCESSING || $vars['node']->task_status == HOSTING_TASK_QUEUED ) {
       $vars['follow_checkbox'] = array(
         '#type' => 'markup',
-        '#markup' => '<label class="follow-checkbox btn btn-default"><input type="checkbox" id="follow"> Follow Logs',
+        '#markup' => '<label class="follow-checkbox btn btn-default"><input type="checkbox" id="follow" checked="checked"> Follow Logs',
       );
 
       $vars['follow_checkbox'] = drupal_render($vars['follow_checkbox']);
@@ -224,6 +224,15 @@ function devshop_projects_preprocess_node(&$vars) {
         $vars['running_label'] = t('Queued');
       }
     }
+    $vars['run_again'] = l(t('Run Again'), "hosting_confirm/{$node->rid}/{$node->ref_type}_{$node->task_type}", array(
+      'query' => array(
+        'token' => drupal_get_token(),
+        'redirect' => 'task-page',
+      ),
+      'attributes' => array(
+        'class' => array('btn btn-default'),
+      )
+    ));
   }
 }
 

--- a/tests/features/bootstrap/FeatureContext.php
+++ b/tests/features/bootstrap/FeatureContext.php
@@ -195,21 +195,6 @@ class FeatureContext extends \Drupal\DrupalExtension\Context\BatchContext implem
   }
 
   /**
-   * @When I select the radio button with the label :label
-   *
-   * @TODO: Remove when PR is merged: https://github.com/jhedstrom/drupalextension/pull/302
-   */
-  public function assertSelectRadioByName($label) {
-    $element = $this->getSession()->getPage();
-    $radiobutton = $element->find('named', array('radio', $this->getSession()->getSelectorsHandler()->xpathLiteral($label)));
-    if ($radiobutton === NULL) {
-      throw new \Exception(sprintf('The radio button with the label "%s" was not found on the page %s', $label, $this->getSession()->getCurrentUrl()));
-    }
-    $value = $radiobutton->getAttribute('value');
-    $radiobutton->selectOption($value, FALSE);
-  }
-  
-  /**
    * @AfterSuite
    */
   public static function deleteProjectCode(AfterSuiteScope $scope)

--- a/themes/boots/boots.css
+++ b/themes/boots/boots.css
@@ -916,12 +916,6 @@ div.hosting-task-retry form, div.hosting-task-retry form input {
   word-wrap: normal;
 }
 
-.follow-checkbox {
-    position: fixed;
-    bottom: 10px;
-    left: 10px;
-    z-index: 10;
-}
 
 .task-details {
   margin-top: 3em;
@@ -1177,4 +1171,28 @@ li.text.code {
 
 .table-responsive {
   overflow: visible;
+}
+
+.task-info {
+    width: 100%;
+
+    position: relative;
+}
+
+.task-info-fixed {
+    width: 73%;
+    top: 20px;
+    position: fixed;
+}
+
+.project-environment-links-fixed {
+    position: fixed;
+    top: 40px;
+    z-index: 1;
+}
+
+.follow-checkbox {
+    position: absolute;
+    right: 10px;
+    z-index: 10;
 }

--- a/themes/boots/node--task.tpl.php
+++ b/themes/boots/node--task.tpl.php
@@ -51,8 +51,13 @@
 
   <?php print $user_picture ?>
 
-  <div class="well well-sm">
+  <div id="task-info" class="task-info well well-sm">
 
+    <?php  if (isset($follow_checkbox)): ?>
+        <div class="follow-logs-checkbox">
+          <?php print $follow_checkbox; ?>
+        </div>
+    <?php endif; ?>
     <h4>
 
       <div class="task-badge pull-left">
@@ -64,6 +69,10 @@
       <?php if (isset($retry)): ?>
         <div class="retry-button pull-right">
           <?php print render($retry); ?>
+        </div>
+      <?php elseif (isset($run_again)): ?>
+        <div class="retry-button pull-right">
+          <?php print render($run_again); ?>
         </div>
       <?php endif; ?>
 
@@ -128,11 +137,6 @@
     </div>
   <?php endif; ?>
 
-    <?php  if (isset($follow_checkbox)): ?>
-        <div class="follow-logs-checkbox">
-            <?php print $follow_checkbox; ?>
-        </div>
-    <?php endif; ?>
 
     <h3><?php print $type; ?></h3>
 

--- a/themes/boots/page.tpl.php
+++ b/themes/boots/page.tpl.php
@@ -123,6 +123,8 @@
         <p class="lead pull-right"><?php print $site_slogan; ?></p>
     <?php endif; ?>
 
+      <nav id="project-environment-links">
+
     <?php if (!empty($title)): ?>
       <h1 class="page-header">
         <?php print $title; ?>
@@ -141,6 +143,7 @@
         <?php endif; ?>
       </h3>
     <?php endif; ?>
+      </nav>
 
     <?php print render($page['header']); ?>
 


### PR DESCRIPTION
- Provide a way to redirect to the task node so users can start watching results right away.
- Position the task header at the top of the page.
